### PR TITLE
Add regression test to make sure invalid json is not parsed

### DIFF
--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -18,6 +18,13 @@ module RJSON
       assert_equal({ 'foo' => { 'bar' => nil }}, r)
     end
 
+    def test_object_key_without_value_raises_exception
+      parser = new_parser '{"foo":}'
+      assert_raises(Racc::ParseError) do
+        parser.parse.result
+      end
+    end
+
     def new_parser string
       tokenizer = Tokenizer.new StringIO.new string
       Parser.new tokenizer


### PR DESCRIPTION
The last change made to this repo was untested. This test will protect that work from regressions.